### PR TITLE
Add comment, bump version to surpass current version online

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi-vector-graphics",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "Draws SVG documents on PIXI.Graphics objects",
   "main": "src/pixi-svg-graphics.js",
   "scripts": {

--- a/src/pixi-svg-graphics.js
+++ b/src/pixi-svg-graphics.js
@@ -236,6 +236,7 @@ SVGGraphics.prototype.clone = function(){
 SVGGraphics.prototype.updateTransform = function () {
     PIXI.DisplayObject.prototype.updateTransform.call(this);
 
+    // Support for vector effect 'non-scaling-strokes'
     if (this._nonScaling) {
         for (var i = 0; i < this.graphicsData.length; i++) {
             if (this.graphicsData[i].lineWidth > 0) {


### PR DESCRIPTION
Diffing the current NPM version (0.0.5) and our current GIT version (0.0.3) only showed some additional code in the GIT (which was commented), for the next release our version should be bumped higher than the current NPM release, so 0.0.6